### PR TITLE
Add noninteractive frontend for libdvd reconfigure

### DIFF
--- a/install-extras.sh
+++ b/install-extras.sh
@@ -100,7 +100,7 @@ sudo apt install gstreamer1.0-plugins-ugly -y
 # installing DVD decryption software
 echo "Installing libdvd-pkg"
 sudo DEBIAN_FRONTEND=noninteractive apt install libdvd-pkg -y
-sudo dpkg-reconfigure libdvd-pkg
+sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure libdvd-pkg
 
 # installing Inkscape
 echo "Installing Inkscape"


### PR DESCRIPTION
This is a followup to #1 

I didn't fully automate the libdvd install because the user prompts are activated during the call to 
```
dpkg-reconfigure libdvd-pkg
```

This is solved the same way as the other merge request, by setting the `DEBIAN_FRONTEND` environment variable to `noninteractive`.